### PR TITLE
Refactor IPC methods for user deletion

### DIFF
--- a/src/ipc-main-listeners/delete-all-users.ts
+++ b/src/ipc-main-listeners/delete-all-users.ts
@@ -2,6 +2,6 @@ import { users } from "@/schema";
 import { db } from "@/utils/db";
 import type { IpcMainListener } from ".";
 
-export const deleteUsers = (async (): Promise<void> => {
+export const deleteAllUsers = (async (): Promise<void> => {
   await db.delete(users);
 }) satisfies IpcMainListener;

--- a/src/ipc-main-listeners/index.ts
+++ b/src/ipc-main-listeners/index.ts
@@ -1,12 +1,12 @@
 import type { ipcMain } from "electron";
-import { deleteUsers } from "./delete-users";
+import { deleteAllUsers } from "./delete-all-users";
 import { fetchUsers } from "./fetch-users";
 import { registerUser } from "./register-user";
 
 export const ipcMainListeners = {
   fetchUsers,
   registerUser,
-  deleteUsers,
+  deleteAllUsers,
 };
 
 export type IpcMainListener = Parameters<typeof ipcMain.handle>[1];

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -18,7 +18,7 @@ interface RegisterUserState {
   success: boolean;
 }
 
-interface DeleteUsersState {
+interface DeleteAllUsersState {
   error: string | null;
   success: boolean;
 }
@@ -60,7 +60,7 @@ export function Home(): React.JSX.Element {
   );
 
   const handleDeleteAllUsers = useCallback(
-    async (_: DeleteUsersState): Promise<DeleteUsersState> => {
+    async (_: DeleteAllUsersState): Promise<DeleteAllUsersState> => {
       try {
         await deleteAllUsers();
         return { error: null, success: true };

--- a/src/pages/home/use-users.ts
+++ b/src/pages/home/use-users.ts
@@ -32,7 +32,7 @@ export function useUsers(): UseUsersReturn {
   );
 
   const deleteAllUsers = useCallback(async (): Promise<void> => {
-    await window.ipcRenderer.invoke("deleteUsers");
+    await window.ipcRenderer.invoke("deleteAllUsers");
     setUsersPromise(Promise.resolve([]));
   }, []);
 
@@ -81,7 +81,7 @@ if (import.meta.vitest) {
             return Promise.resolve(mockUsers);
           case "registerUser":
             return Promise.resolve(mockNewUser);
-          case "deleteUsers":
+          case "deleteAllUsers":
             return Promise.resolve();
           default:
             throw new Error(`Unknown channel: ${channel satisfies never}`);
@@ -132,7 +132,7 @@ if (import.meta.vitest) {
         await result.current.deleteAllUsers();
       });
 
-      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("deleteUsers");
+      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("deleteAllUsers");
 
       const users = await result.current.usersPromise;
       expect(users).toEqual([]);
@@ -165,7 +165,7 @@ if (import.meta.vitest) {
         if (channel === "fetchUsers") {
           return Promise.resolve(mockUsers);
         }
-        if (channel === "deleteUsers") {
+        if (channel === "deleteAllUsers") {
           return Promise.reject(error);
         }
         return Promise.resolve();

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,20 +3,16 @@ import type { ipcMainListeners } from "./ipc-main-listeners";
 
 export type AllowedChannel = keyof typeof ipcMainListeners;
 
-type InvokeArgs<K extends AllowedChannel> = Parameters<
-  (typeof ipcMainListeners)[K]
->[1];
-
-type IsOptional<T> = undefined extends T ? true : false;
+// Extract all arguments except the first one (event argument)
+type InvokeArgs<K extends AllowedChannel> =
+  Parameters<(typeof ipcMainListeners)[K]> extends [unknown, ...infer Args]
+    ? Args
+    : never;
 
 const api = {
   invoke: <K extends AllowedChannel>(
     channel: K,
-    ...args: IsOptional<InvokeArgs<K>> extends true // Is the argument optional?
-      ? [InvokeArgs<K>?] // If so, wrap it in an array and make it optional
-      : InvokeArgs<K> extends undefined // Is the argument undefined?
-        ? [] // If so, pass an empty array
-        : [InvokeArgs<K>] // Otherwise, wrap it in an array
+    ...args: InvokeArgs<K> extends [] ? [] : InvokeArgs<K>
   ): Promise<Awaited<ReturnType<(typeof ipcMainListeners)[K]>>> => {
     return ipcRenderer.invoke(channel, ...args);
   },


### PR DESCRIPTION
Simplify argument handling in the `ipcRenderer` invoke method and replace `deleteUsers` with `deleteAllUsers` in the IPC main listeners and related logic.